### PR TITLE
Add build.rs for static compilation

### DIFF
--- a/plyoreacto/build.rs
+++ b/plyoreacto/build.rs
@@ -1,0 +1,11 @@
+fn main() {
+    #[cfg(all(target_os = "linux", target_env = "musl"))]
+    {
+        // List here all the native libraries that need to be added to the
+        // binary. Make sure to add the corresponding package to the
+        // Dockerfile (namely, the Alpine package that contains the .a files).
+        println!("cargo:rustc-link-lib=static=zmq");
+        println!("cargo:rustc-link-lib=static=stdc++");
+        println!("cargo:rustc-link-lib=static=sodium");
+    }
+}


### PR DESCRIPTION
This PR adds a `build.rs` file that allows for static compilation using the container at https://github.com/waltermoreira/alpine-rust.

To statically compile `plyoreacto`:

```bash
git clone https://github.com/waltermoreira/alpine-rust.git
cd alpine-rust
sudo SRC=/path/to/plyoreacto docker-compose run alpine-rust --release
```

Then, get the static binary from `/path/to/plyoreacto/target/x86_64-alpine-linux-musl/release/plyoreacto`.